### PR TITLE
Update for newer version of MC and MSM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 FROM ubuntu:14.04
 MAINTAINER Chris Collins <collins.christopher@gmail.com>
 
-ENV PKGS curl anacron openjdk-7-jre-headless
+ENV PKGS screen rsync zip wget curl anacron openjdk-7-jre-headless
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y $PKGS && \
@@ -26,6 +26,6 @@ RUN ln -s /etc/init.d/msm /usr/local/bin/msm
 
 ADD startup.sh /startup.sh
 
-EXPOSE 25565 
+EXPOSE 25565
 
 CMD ["/bin/bash", "/startup.sh"]

--- a/startup.sh
+++ b/startup.sh
@@ -2,11 +2,12 @@
 
 yes | /usr/local/bin/msm update
 
-/usr/local/bin/msm jargroup create minecraft https://s3.amazonaws.com/MinecraftDownload/launcher/minecraft_server.jar
+/usr/local/bin/msm jargroup create minecraft https://s3.amazonaws.com/Minecraft.Download/versions/1.8.9/minecraft_server.1.8.9.jar
 /usr/local/bin/msm server create $(hostname)
 /usr/local/bin/msm $(hostname) jar minecraft
 
 VERSION="minecraft/$(ls /opt/msm/versioning/minecraft | sort |tail -n1 |sed 's/.sh//')"
 /bin/echo "msm-version=$VERSION" >> /opt/msm/servers/$(hostname)/server.properties
+/bin/echo "eula=true" > /opt/msm/servers/$(hostname)/eula.txt
 
-/usr/local/bin/msm $(hostname) start
+/usr/local/bin/msm $(hostname) start && tail -f /dev/null


### PR DESCRIPTION
Not sure if this is still maintained, so took a shot.

Since MSM forks to the background, a way to stop the container from automatically stopping is needed. `tail -f /dev/null` does the trick (hats off to [this guy](http://kimh.github.io/blog/en/docker/gotchas-in-writing-dockerfile-en/#hack_to_run_container_in_the_background)). It also has a couple of dependencies, so these are installed on top of the base image.

Also, since the used server version is way outdated, I added the most recent version.
